### PR TITLE
feat: Integrate advanced NLP for news curation

### DIFF
--- a/client/src/components/CuratedNewsCard.jsx
+++ b/client/src/components/CuratedNewsCard.jsx
@@ -35,19 +35,32 @@ const CuratedNewsCard = ({ article }) => {
           </a>
         </h3>
         
-        {article.description && (
-          <p className="text-gray-600 mb-4 line-clamp-3">
-            {article.description}
-          </p>
-        )}
+        {article.aiSummary ? (
+          <>
+            <p className="text-gray-700 font-semibold text-sm mb-1">AI Summary:</p>
+            <p className="text-gray-600 mb-4 line-clamp-3">{article.aiSummary}</p>
+          </>
+        ) : article.description ? (
+          <>
+            <p className="text-gray-700 font-semibold text-sm mb-1">Description:</p>
+            <p className="text-gray-600 mb-4 line-clamp-3">{article.description}</p>
+          </>
+        ) : null}
         
-        <div className="flex justify-between items-center text-sm text-gray-500">
+        <div className="flex justify-between items-center text-sm text-gray-500 mb-3"> {/* Added mb-3 for spacing before tags */}
           <span>Source: {article.sourceName || 'N/A'}</span>
-          {/* Future: Add tags or other info here */}
         </div>
-         {article.keywordsUsed && article.keywordsUsed.length > 0 && (
-          <div className="mt-2">
-            <span className="text-xs text-gray-400">Keywords: {article.keywordsUsed.join(', ')}</span>
+
+        {article.tags && article.tags.length > 0 && (
+          <div className="mt-3 pt-2 border-t border-gray-100">
+            <p className="text-xs text-gray-500 mb-1">Tags:</p>
+            <div className="flex flex-wrap gap-1">
+              {article.tags.slice(0, 5).map((tag, index) => ( // Show up to 5 tags
+                <span key={index} className="text-xs bg-gray-200 text-gray-700 px-2 py-0.5 rounded-full">
+                  {tag}
+                </span>
+              ))}
+            </div>
           </div>
         )}
       </div>

--- a/server/models/CuratedNews.js
+++ b/server/models/CuratedNews.js
@@ -30,6 +30,10 @@ const CuratedNewsSchema = new mongoose.Schema({
     type: String,
     trim: true,
   },
+  aiSummary: { // AI-generated summary
+    type: String,
+    trim: true,
+  },
   imageUrl: {
     type: String,
     trim: true,

--- a/server/package.json
+++ b/server/package.json
@@ -8,6 +8,7 @@
     "dev": "nodemon server.js"
   },
   "dependencies": {
+    "@huggingface/inference": "^3.13.0",
     "axios": "^1.6.0",
     "bcryptjs": "^2.4.3",
     "cors": "^2.8.5",

--- a/server/services/nlpService.js
+++ b/server/services/nlpService.js
@@ -1,0 +1,158 @@
+const { InferenceClient } = require('@huggingface/inference');
+
+// Ensure HF_TOKEN is loaded from .env by the time this module is initialized,
+// or by the time the client is first used.
+// dotenv should be configured in server.js already.
+const HF_TOKEN = process.env.HF_TOKEN;
+
+let inferenceClient;
+
+if (HF_TOKEN) {
+  inferenceClient = new InferenceClient(HF_TOKEN);
+  console.log('Hugging Face Inference Client initialized.');
+} else {
+  console.warn('HF_TOKEN not found in environment variables. NLP service will not be functional.');
+  // Optionally, create a mock client or ensure functions handle the undefined client gracefully.
+  inferenceClient = null; 
+}
+
+/**
+ * Classifies a given text using a zero-shot classification model.
+ * @param {string} text The input text to classify.
+ * @param {string[]} candidateLabels An array of candidate labels for classification.
+ * @param {string} model Optional: The model to use (defaults to facebook/bart-large-mnli).
+ * @returns {Promise<object|null>} The classification result from Hugging Face API, or null if service is not available or error.
+ */
+async function classifyTextZeroShot(text, candidateLabels, model = 'facebook/bart-large-mnli') {
+  if (!inferenceClient) {
+    console.error('Hugging Face client not initialized. Cannot perform zero-shot classification.');
+    return null;
+  }
+
+  if (!text || !candidateLabels || candidateLabels.length === 0) {
+    console.error('Invalid input for zero-shot classification: Text and candidateLabels are required.');
+    return null;
+  }
+
+  try {
+    const result = await inferenceClient.zeroShotClassification({
+      model: model,
+      inputs: [text], // API expects an array of inputs
+      parameters: { candidate_labels: candidateLabels }
+    });
+    // The result structure is typically an array of objects, one for each input.
+    // Since we send one input, we expect one result.
+    // Each result object contains: sequence, labels, scores
+    return result[0]; 
+  } catch (error) {
+    console.error(`Error during zero-shot classification with model ${model}:`, error.message);
+    if (error.response) { // Axios-like error structure from HF client
+        console.error('HF API Error Details:', error.response.data);
+    }
+    return null;
+  }
+}
+
+/**
+ * Extracts named entities from a given text using a token classification model.
+ * @param {string} text The input text from which to extract entities.
+ * @param {string} model Optional: The NER model to use (defaults to dbmdz/bert-large-cased-finetuned-conll03-english).
+ * @returns {Promise<string[]|null>} An array of unique entity strings, or null if service not available or error.
+ */
+async function extractEntitiesNER(text, model = 'dbmdz/bert-large-cased-finetuned-conll03-english') {
+  if (!inferenceClient) {
+    console.error('Hugging Face client not initialized. Cannot perform NER.');
+    return null;
+  }
+  if (!text || text.trim() === '') {
+    console.error('Invalid input for NER: Text is required.');
+    return null;
+  }
+
+  try {
+    const results = await inferenceClient.tokenClassification({
+      model: model,
+      inputs: text
+    });
+
+    // Results is an array of entities, e.g.:
+    // [ { entity_group: 'ORG', score: 0.99, word: 'Hugging Face', start: 0, end: 12 }, ... ]
+    
+    const entities = new Set();
+    const minConfidence = 0.85; // Confidence threshold
+
+    for (const entity of results) {
+      if (entity.score >= minConfidence) {
+        // Simple tag: use the entity word. Replace spaces for consistency if desired.
+        // Avoid single characters or very short tags if they are noisy.
+        // The 'word' from HF tokenClassification is usually the recognized entity string.
+        if (entity.word.length > 2 && !entity.word.startsWith('##')) {
+           entities.add(entity.word.trim().toLowerCase().replace(/ /g, '-'));
+        }
+      }
+    }
+    return Array.from(entities);
+  } catch (error) {
+    console.error(`Error during NER with model ${model}:`, error.message);
+    if (error.response) {
+        console.error('HF API Error Details:', error.response.data);
+    }
+    return null;
+  }
+}
+
+}
+
+/**
+ * Summarizes a given text using a summarization model.
+ * @param {string} textToSummarize The input text to summarize.
+ * @param {string} model Optional: The summarization model to use (defaults to facebook/bart-large-cnn).
+ * @param {number} minLength Optional: Minimum length of the summary.
+ * @param {number} maxLength Optional: Maximum length of the summary.
+ * @returns {Promise<string|null>} The summary text, or null if service not available or error.
+ */
+async function summarizeText(textToSummarize, model = 'facebook/bart-large-cnn', minLength = 30, maxLength = 150) {
+  if (!inferenceClient) {
+    console.error('Hugging Face client not initialized. Cannot perform summarization.');
+    return null;
+  }
+  if (!textToSummarize || textToSummarize.trim().length < minLength * 0.8) { // Ensure text is substantial enough
+    console.warn('Input text too short for summarization or invalid.');
+    return null; 
+  }
+
+  // Truncate text to avoid exceeding model token limits (e.g., 1024 tokens for bart-large-cnn)
+  // A simple character limit for now, tokenization is more accurate but complex here.
+  const MAX_INPUT_CHAR_LENGTH = 3000; // Roughly 750-1000 tokens
+  let effectiveText = textToSummarize;
+  if (effectiveText.length > MAX_INPUT_CHAR_LENGTH) {
+    effectiveText = effectiveText.substring(0, MAX_INPUT_CHAR_LENGTH);
+    console.log(`Input text truncated to ${MAX_INPUT_CHAR_LENGTH} characters for summarization.`);
+  }
+
+  try {
+    const result = await inferenceClient.summarization({
+      model: model,
+      inputs: effectiveText,
+      parameters: {
+        min_length: minLength,
+        max_length: maxLength,
+      }
+    });
+    // Result is typically { summary_text: "..." }
+    return result.summary_text;
+  } catch (error) {
+    console.error(`Error during summarization with model ${model}:`, error.message);
+    if (error.response) {
+        console.error('HF API Error Details:', error.response.data);
+    }
+    return null;
+  }
+}
+
+module.exports = {
+  classifyTextZeroShot,
+  extractEntitiesNER,
+  summarizeText, // New export
+  isNlpServiceAvailable: () => !!inferenceClient
+};


### PR DESCRIPTION
I've implemented deeper AI capabilities for the news curation feature:

Server-Side:
- NLP Service (`nlpService.js`):
    - I added `classifyTextZeroShot` using Hugging Face Inference API (model: `facebook/bart-large-mnli`) for improved article categorization.
    - I added `extractEntitiesNER` (model: `dbmdz/bert-large-cased-finetuned-conll03-english`) for extracting named entities to be used as tags.
    - I added `summarizeText` (model: `facebook/bart-large-cnn`) for generating AI summaries of articles.
    - This requires `HF_TOKEN` in your server `.env`.
- News Processing (`curatedNewsController.js`):
    - I refactored `_internalFetchAndProcessNews` to prioritize NLP for classification. It falls back to keyword matching if NLP fails or confidence is low.
    - It uses NER for generating article tags, with fallback to keyword-based tags.
    - It generates and stores an AI summary if the NLP service is available and the text is suitable.
    - It sets a `processedByAI` flag and stores `aiSummary` in the `CuratedNews` model.
- Model: I added an `aiSummary` field to `CuratedNewsSchema`.
- Dependencies: I added `@huggingface/inference` to `server/package.json`.

Client-Side:
- News Card (`CuratedNewsCard.jsx`):
    - I updated this to display `aiSummary` with a label if available, falling back to the original `description`.
    - I updated this to display NER-generated (or fallback) `tags` as badges.

Note: Testing of these specific NLP enhancements is pending. This commit saves the current implementation progress.